### PR TITLE
Fix vanilla bug causing AI to not break exports to lost planets

### DIFF
--- a/SR2 Community Patch/scripts/server/empire_ai/weasel/Resources.as
+++ b/SR2 Community Patch/scripts/server/empire_ai/weasel/Resources.as
@@ -472,7 +472,7 @@ final class Resources : AIComponent {
 	void cancelRequest(ImportData@ data) {
 		if(data.beingMet) {
 			breakImport(data);
-			active.remove(data);
+			requested.remove(data);
 		}
 		else {
 			requested.remove(data);


### PR DESCRIPTION
The `cancelRequest` method has two branches, one of them just removes the import data from the requested list, but the other calls `breakImport`. In `breakImport` the resource is removed from active/used and added to requested. Then control flow returns to `cancelRequest` and the existing code tries to remove the resource from active a second time, leaving it in requested, and not freeing the export.

I was messing around in my own mod with a trait that razes planets to the ground and discovered that the AI was leaving a lot of resources exported to since abandoned planets, despite the PlanetAI logic calling `killImportsTo` on the abandoned planets correctly. I tracked it down to the `cancelRequest` method, and I think swapping the line to remove the resource from requested has fixed the bug.

As a side note I'd love to integrate all the existing bug fixes here into my own mod in development, but I can't see a license for this project?