### PR TITLE
Fix PlanetPopup obscuring cargo icons when a planet has strength

### DIFF
--- a/SR2 Community Patch/scripts/gui/overlays/PlanetPopup.as
+++ b/SR2 Community Patch/scripts/gui/overlays/PlanetPopup.as
@@ -58,39 +58,39 @@ class PlanetPopup : Popup {
 
 	PlanetPopup(BaseGuiElement@ parent) {
 		super(parent);
-		size = vec2i(190, 186);
+		size = vec2i(190, 216);
 
 		@name = GuiText(this, Alignment(Left+50, Top+6, Right-4, Top+28));
 		@ownerName = GuiText(this, Alignment(Left+48, Top+28, Right-6, Top+46));
 		ownerName.horizAlign = 1.0;
 
-		@objView = Gui3DObject(this, Alignment(Left+4, Top+50, Right-4, Top+120));
+		@objView = Gui3DObject(this, Alignment(Left+4, Top+53, Right-4, Top+123));
 
-		@cargo = GuiCargoDisplay(objView, Alignment(Left, Top, Right, Top+25));
+		@cargo = GuiCargoDisplay(this, Alignment(Left+4, Top+50, Right-4, Top+75));
 
 		@defIcon = GuiSprite(this, Alignment(Left+4, Top+50, Width=40, Height=40));
 		defIcon.desc = icons::Defense;
 		setMarkupTooltip(defIcon, locale::TT_IS_DEFENDING);
 		defIcon.visible = false;
 
-		@strength = GuiProgressbar(this, Alignment(Left+8, Top+53, Right-8, Top+75));
-		strength.visible = false;
+		@strength = GuiProgressbar(this, Alignment(Left+3, Bottom-61, Right-4, Bottom-35));
 		strength.tooltip = locale::FLEET_STRENGTH;
 
-		GuiSprite strIcon(strength, Alignment(Left-8, Top-9, Left+24, Bottom-8), icons::Strength);
+		GuiSprite strIcon(strength, Alignment(Left, Top, Left+24, Bottom), icons::Strength);
 		strIcon.noClip = true;
 
 		GuiSkinElement band(this, Alignment(Left+3, Bottom-35, Right-4, Bottom-2), SS_SubTitle);
 		band.color = Color(0xaaaaaaff);
 
-		@popBox = BaseGuiElement(this, Alignment(Left+3, Bottom-93, Left+50, Bottom-61));
+		@popBox = BaseGuiElement(this, Alignment(Left+3, Bottom-119, Left+50, Bottom-87));
+
 		@popIcon = GuiSprite(popBox, Alignment(Left-12, Top+2, Left+24, Bottom+6));
 		popIcon.desc = icons::Population;
 		@popValue = GuiText(popBox, Alignment(Left+26, Top+12, Right, Height=20));
 		popIcon.tooltip = locale::POPULATION;
 		popValue.tooltip = locale::POPULATION;
 
-		@loyBox = BaseGuiElement(this, Alignment(Right-50, Bottom-93, Right-5, Bottom-61));
+		@loyBox = BaseGuiElement(this, Alignment(Right-50, Bottom-119, Right-5, Bottom-87));
 		@loyIcon = GuiSprite(loyBox, Alignment(Right-24, Top+8, Right, Bottom-1));
 		loyIcon.desc = icons::Loyalty;
 		@loyValue = GuiText(loyBox, Alignment(Right-50, Top+12, Right-26, Height=20));
@@ -104,7 +104,7 @@ class PlanetPopup : Popup {
 		statusBox.noClip = true;
 		statusBox.visible = false;
 
-		@health = GuiProgressbar(this, Alignment(Left+3, Bottom-61, Right-4, Bottom-35));
+		@health = GuiProgressbar(this, Alignment(Left+3, Bottom-87, Right-4, Bottom-61));
 
 		auto@ healthIcon = GuiSprite(health, Alignment(Left+2, Top+1, Width=24, Height=24), icons::Health);
 		healthIcon.noClip = true;
@@ -137,7 +137,7 @@ class PlanetPopup : Popup {
 			flags |= SF_Active;
 		if(isSelectable && Hovered)
 			flags |= SF_Hovered;
-		
+
 		Empire@ owner = pl.visibleOwner;
 		Color color;
 		if(owner !is null) {
@@ -352,12 +352,10 @@ class PlanetPopup : Popup {
 		double currentStrength = pl.getFleetStrength() * 0.001;
 		double totalStrength = pl.getFleetMaxStrength() * 0.001;
 		if (totalStrength == 0) {
-			strength.visible = false;
 			strength.progress = 0.f;
 			strength.frontColor = Color(0xff6a00ff);
 			strength.text = "--";
 		} else {
-			strength.visible = true;
 			strength.progress = currentStrength / totalStrength;
 			if (strength.progress > 1.001f) {
 				strength.progress = 1.f;


### PR DESCRIPTION
Now the Strength and HP progress bars are shown in the same style as orbitals, below the planet icon, which allows the cargo icons to display unobscured

![Screenshot_20200813_121822](https://user-images.githubusercontent.com/13869843/90131092-73a64a00-dd63-11ea-8d3a-92c78fc9a568.png)
![Screenshot_20200813_121956](https://user-images.githubusercontent.com/13869843/90131094-74d77700-dd63-11ea-8537-155987d2660b.png)

Ignore the non vanilla cargo type and resources in the pictures, I ported this fix from my mod and took the pictures then.