### PR TITLE
Fix AddLocalDefense bugs

### DIFF
--- a/SR2 Community Patch/scripts/definitions/generic_effects.as
+++ b/SR2 Community Patch/scripts/definitions/generic_effects.as
@@ -3633,48 +3633,60 @@ class AddLocalDefense : GenericEffect {
 		if(disable_in_combat.boolean && obj.inCombat)
 			tickDefense = 0;
 
-		if(dat.design is null) {
-			int maxSize = -1;
-			if(stop_filled.boolean && obj.hasLeaderAI) {
-				maxSize = obj.SupplyCapacity - obj.SupplyUsed;
-				if(maxSize <= 0)
+		// Loop while have defense for this tick to build with
+		// Fixes vanilla issue blowing all labor on the first support
+		// even when labor would be leftover
+		while (tickDefense > 0) {
+			if(dat.design is null) {
+				int maxSize = -1;
+				if(stop_filled.boolean && obj.hasLeaderAI) {
+					maxSize = obj.SupplyCapacity - obj.SupplyUsed;
+					if(maxSize <= 0)
+						return;
+				}
+				if (obj.hasLeaderAI && !obj.canGainSupports)
 					return;
-			}
-			if(obj.hasLeaderAI && !obj.canGainSupports)
-				return;
-			if(dat.timeout > 0) {
-				dat.timeout -= time;
-				return;
-			}
+				if(dat.timeout > 0) {
+					dat.timeout -= time;
+					return;
+				}
 
-			@dat.design = getDefenseDesign(obj.owner, secondDefense, satellite=build_satellites.boolean, maxSize=maxSize);
-			if(dat.design !is null)
-				dat.labor = getLaborCost(dat.design, 1);
-			else
-				dat.timeout = 30.0;
-		}
-		else {
-			if(overflow_global.boolean) {
-				if(!obj.hasLeaderAI || obj.SupplyUsed + uint(dat.design.size) > obj.SupplyCapacity) {
-					if(dat.global != secondDefense) {
-						obj.owner.modDefenseRate((secondDefense-dat.global) * global_factor.decimal);
-						dat.global = secondDefense;
+				@dat.design = getDefenseDesign(obj.owner, secondDefense, satellite=build_satellites.boolean, maxSize=maxSize);
+				if (dat.design !is null) {
+					dat.labor = getLaborCost(dat.design, 1);
+				}
+				else {
+					dat.timeout = 30.0;
+					return;
+				}
+			}
+			if(dat.design !is null)  {
+				if(overflow_global.boolean) {
+					if(!obj.hasLeaderAI || obj.SupplyUsed + uint(dat.design.size) > obj.SupplyCapacity) {
+						if(dat.global != secondDefense) {
+							obj.owner.modDefenseRate((secondDefense-dat.global) * global_factor.decimal);
+							dat.global = secondDefense;
+						}
+						return;
 					}
-					return;
+					else if(dat.global != 0) {
+						obj.owner.modDefenseRate(-dat.global * global_factor.decimal);
+						dat.global = 0;
+					}
 				}
-				else if(dat.global != 0) {
-					obj.owner.modDefenseRate(-dat.global * global_factor.decimal);
-					dat.global = 0;
-				}
-			}
 
-			dat.labor -= tickDefense;
-			if(dat.labor <= 0) {
-				Object@ leader;
-				if(obj.hasLeaderAI && obj.canGainSupports)
-					@leader = obj;
-				createShip(obj, dat.design, obj.owner, leader, false, true);
-				@dat.design = null;
+				// Only use labor equal to what we needed for the ship
+				double take = min(tickDefense, dat.labor);
+				dat.labor -= take;
+				tickDefense -= take;
+
+				if(dat.labor <= 0) {
+					Object@ leader;
+					if(obj.hasLeaderAI && obj.canGainSupports)
+						@leader = obj;
+					createShip(obj, dat.design, obj.owner, leader, false, true);
+					@dat.design = null;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
No longer stops building after the first ship, so labor available beyond the labor cost will now be put to use. Also doesn't skip a tick if a design needs to be picked, which was causing low labor ships to be built at effectively half speed (tick 1 pick design, tick 2 build design)