### PR TITLE
Readable GlobalBar tooltips

### DIFF
--- a/SR2 Community Patch/locales/english/CP_resources.txt
+++ b/SR2 Community Patch/locales/english/CP_resources.txt
@@ -1,0 +1,62 @@
+GTT_MONEY: <<
+	[font=Medium]Money[/font]
+	[color=#aaa][i]Every budget cycle of 3 minutes generates new money to spend. Any money not spent after the budget cycle ends is put into [img=$4;20/] welfare.[/i][/color]
+
+	Remaining Budget: [vspace=-16/][right]$1[/right][hr=#333/]
+	Time Remaining: [vspace=-16/][right]$3[/right][hr=#333/]
+	Upcoming Budget: [vspace=-16/][right]$2[/right][hr=#333/]
+>>
+GTT_INFLUENCE: <<
+	[font=Medium]Influence[/font]
+	[color=#aaa][i]Influence points are used to trigger diplomatic actions and win galactic senate votes. If storing more points than your optimal storage cap (based on your total generation), your generation rate will be decreased.[/i][/color]
+
+	Available Points: [vspace=-16/][right]$1[/right][hr=#333/]
+	Optimal Storage: [vspace=-16/][right]$2[/right][hr=#333/]
+	Generation Rate: [vspace=-16/][right]$3[/right][hr=#333/]
+
+	Influence Stake: [vspace=-16/][right]$5[/right][hr=#333/]
+	Galactic Stake Percentage: [vspace=-16/][right]$4[/right][hr=#333/]
+
+	[color=#aaa][i]Influence Stake is provided by influence buildings. The percentage of the total influence stake from all empires that you currently control determines your influence generation rate.[/i][/color]
+>>
+
+GTT_ENERGY: <<
+	[font=Medium]Energy[/font]
+	[color=#aaa][i]Energy is used to activate abilities on artifacts found across the galaxy. The more Energy you are currently storing above your free storage cap, the more your generation rate is reduced.[/i][/color]
+
+	Available Energy: [vspace=-16/][right]$1[/right][hr=#333/]
+	Generation Rate: [vspace=-16/][right]$2[/right][hr=#333/]
+	Free Storage: [vspace=-16/][right]$3[/right][hr=#333/]
+	Storage Penalty: [vspace=-16/][right]$4[/right][hr=#333/]
+>>
+
+GTT_FTL: <<
+	[font=Medium]FTL Energy[/font]
+	[color=#aaa][i]FTL Energy is paid to engage the faster-than-light drives on your ships.[/i][/color]
+
+	Available FTL: [vspace=-16/][right]$1[/right][hr=#333/]
+	Maximum Storage: [vspace=-16/][right]$2[/right][hr=#333/]
+	Generation Rate: [vspace=-16/][right]$3[/right][hr=#333/]
+>>
+
+GTT_RESEARCH: <<
+	[font=Medium]Research[/font]
+	[color=#aaa][i]Research points can be spent to unlock various technologies in the research grid. Research generation goes down over time as you generate more points.[/i][/color]
+
+	Available Research Points: [vspace=-16/][right]$1[/right][hr=#333/]
+	Generation Rate: [vspace=-16/][right]$2[/right][hr=#333/]
+>>
+
+GTT_RESEARCH_TECH: <<
+	Currently Researching: [right][b][color=$3]$1[/color][/b] (ETA: $2)[/right]
+>>
+
+GTT_DEFENSE: <<
+	[font=Medium]Global Defense[/font]
+	[color=#aaa][i]Global defense automatically creates support ships on planets or systems you have indicated to use it. Right click a system's star to mark it for global defense use. Every point of defense counts as 2 labor for support ship spawning.[/i][/color]
+
+	Global Defense Rate: [vspace=-16/][right]$1[/right][hr=#333/]
+	Defense Reserve: [vspace=-16/][right]$3 / $2[/right][hr=#333/]
+
+	[color=#aaa][i]Defense reserve is filled up before ships are spawned automatically. If the defense reserve is full, it can be deployed at any planet to spawn defense ships. While full, global defense generation automatically spawns ships as usual.[/i][/color]
+>>

--- a/SR2 Community Patch/locales/english/CP_resources.txt
+++ b/SR2 Community Patch/locales/english/CP_resources.txt
@@ -1,22 +1,27 @@
+GTT_ALIGNED_STAT: <<
+	$1: [vspace=-16/][right]$2[/right][hr=#333/]
+>>
+GTT_ALIGNED_STATC: <<
+	$1: [vspace=-16/][right][color=$3]$2[/color][/right][hr=#333/]
+>>
 GTT_MONEY: <<
 	[font=Medium]Money[/font]
 	[color=#aaa][i]Every budget cycle of 3 minutes generates new money to spend. Any money not spent after the budget cycle ends is put into [img=$4;20/] welfare.[/i][/color]
 
-	Remaining Budget: [vspace=-16/][right]$1[/right][hr=#333/]
-	Time Remaining: [vspace=-16/][right]$3[/right][hr=#333/]
-	Upcoming Budget: [vspace=-16/][right]$2[/right][hr=#333/]
+	[bbloc=#GTT_ALIGNED_STAT:Remaining Budget:$1/]
+	[bbloc=#GTT_ALIGNED_STAT:Time Remaining:$3/]
+	[bbloc=#GTT_ALIGNED_STAT:Upcoming Budget:$2/]
 >>
 GTT_INFLUENCE: <<
 	[font=Medium]Influence[/font]
 	[color=#aaa][i]Influence points are used to trigger diplomatic actions and win galactic senate votes. If storing more points than your optimal storage cap (based on your total generation), your generation rate will be decreased.[/i][/color]
 
-	Available Points: [vspace=-16/][right]$1[/right][hr=#333/]
-	Optimal Storage: [vspace=-16/][right]$2[/right][hr=#333/]
-	Generation Rate: [vspace=-16/][right]$3[/right][hr=#333/]
+	[bbloc=#GTT_ALIGNED_STAT:Available Points:$1/]
+	[bbloc=#GTT_ALIGNED_STAT:Optimal Storage:$2/]
+	[bbloc=#GTT_ALIGNED_STAT:Generation Rate:$3/]
 
-	Influence Stake: [vspace=-16/][right]$5[/right][hr=#333/]
-	Galactic Stake Percentage: [vspace=-16/][right]$4[/right][hr=#333/]
-
+	[bbloc=#GTT_ALIGNED_STAT:Influence Stake:$5/]
+	[bbloc=#GTT_ALIGNED_STAT:Galactic Stake Percentage:$4/]
 	[color=#aaa][i]Influence Stake is provided by influence buildings. The percentage of the total influence stake from all empires that you currently control determines your influence generation rate.[/i][/color]
 >>
 
@@ -24,27 +29,27 @@ GTT_ENERGY: <<
 	[font=Medium]Energy[/font]
 	[color=#aaa][i]Energy is used to activate abilities on artifacts found across the galaxy. The more Energy you are currently storing above your free storage cap, the more your generation rate is reduced.[/i][/color]
 
-	Available Energy: [vspace=-16/][right]$1[/right][hr=#333/]
-	Generation Rate: [vspace=-16/][right]$2[/right][hr=#333/]
-	Free Storage: [vspace=-16/][right]$3[/right][hr=#333/]
-	Storage Penalty: [vspace=-16/][right]$4[/right][hr=#333/]
+	[bbloc=#GTT_ALIGNED_STAT:Available Energy:$1/]
+	[bbloc=#GTT_ALIGNED_STAT:Generation Rate:$2/]
+	[bbloc=#GTT_ALIGNED_STAT:Free Storage:$3/]
+	[bbloc=#GTT_ALIGNED_STAT:Storage Penalty:$4/]
 >>
 
 GTT_FTL: <<
 	[font=Medium]FTL Energy[/font]
 	[color=#aaa][i]FTL Energy is paid to engage the faster-than-light drives on your ships.[/i][/color]
 
-	Available FTL: [vspace=-16/][right]$1[/right][hr=#333/]
-	Maximum Storage: [vspace=-16/][right]$2[/right][hr=#333/]
-	Generation Rate: [vspace=-16/][right]$3[/right][hr=#333/]
+	[bbloc=#GTT_ALIGNED_STAT:Available FTL:$1/]
+	[bbloc=#GTT_ALIGNED_STAT:Maximum Storage:$2/]
+	[bbloc=#GTT_ALIGNED_STAT:Generation Rate:$3/]
 >>
 
 GTT_RESEARCH: <<
 	[font=Medium]Research[/font]
 	[color=#aaa][i]Research points can be spent to unlock various technologies in the research grid. Research generation goes down over time as you generate more points.[/i][/color]
 
-	Available Research Points: [vspace=-16/][right]$1[/right][hr=#333/]
-	Generation Rate: [vspace=-16/][right]$2[/right][hr=#333/]
+	[bbloc=#GTT_ALIGNED_STAT:Available Research Points:$1/]
+	[bbloc=#GTT_ALIGNED_STAT:Generation Rate:$2/]
 >>
 
 GTT_RESEARCH_TECH: <<
@@ -55,8 +60,21 @@ GTT_DEFENSE: <<
 	[font=Medium]Global Defense[/font]
 	[color=#aaa][i]Global defense automatically creates support ships on planets or systems you have indicated to use it. Right click a system's star to mark it for global defense use. Every point of defense counts as 2 labor for support ship spawning.[/i][/color]
 
-	Global Defense Rate: [vspace=-16/][right]$1[/right][hr=#333/]
-	Defense Reserve: [vspace=-16/][right]$3 / $2[/right][hr=#333/]
-
+	[bbloc=#GTT_ALIGNED_STAT:Global Defense Rate:$1/]
+	[bbloc=#GTT_ALIGNED_STAT:Defense Reserve:$3 / $2/]
 	[color=#aaa][i]Defense reserve is filled up before ships are spawned automatically. If the defense reserve is full, it can be deployed at any planet to spawn defense ships. While full, global defense generation automatically spawns ships as usual.[/i][/color]
+>>
+GTT_BONUS_MONEY: <<|
+	[font=Subtitle][b]Special Funds:[/b] [vspace=-16/][right][color=#0f0]$1[/color][/right][/font][hr=#333/]
+	[color=#aaa][i]Special funds are collected from various one-time sources such as Profiteering cards or Anomalies, and will carry over between budgets if not spent.[/i][/color]
+>>
+
+GTT_DEBT_PENALTY: <<
+	[color=#f00][b]Debt Growth Penalty:[/b] [vspace=-16/][right]$1[/right][/color][hr=#333/]
+	[color=#aaa][i]Being in debt reduces population growth rate on all your planets.[/i][/color]
+>>
+
+GTT_FLEET_PENALTY: <<
+	[color=#f00][b]Debt Fleet Strength Penalty:[/b] [vspace=-16/][right]$1[/right][/color][hr=#333/]
+	[color=#aaa][i]Being in massive debt reduces the strength of all your fleets.[/i][/color]
 >>

--- a/SR2 Community Patch/locales/english/CP_resources.txt
+++ b/SR2 Community Patch/locales/english/CP_resources.txt
@@ -1,8 +1,5 @@
 GTT_ALIGNED_STAT: <<
-	$1: [vspace=-16/][right]$2[/right][hr=#333/]
->>
-GTT_ALIGNED_STATC: <<
-	$1: [vspace=-16/][right][color=$3]$2[/color][/right][hr=#333/]
+	$1: [vspace=-16/][right]$2[/right][hr=#333/][vspace=-16/]
 >>
 GTT_MONEY: <<
 	[font=Medium]Money[/font]
@@ -33,6 +30,7 @@ GTT_ENERGY: <<
 	[bbloc=#GTT_ALIGNED_STAT:Generation Rate:$2/]
 	[bbloc=#GTT_ALIGNED_STAT:Free Storage:$3/]
 	[bbloc=#GTT_ALIGNED_STAT:Storage Penalty:$4/]
+
 >>
 
 GTT_FTL: <<
@@ -42,6 +40,7 @@ GTT_FTL: <<
 	[bbloc=#GTT_ALIGNED_STAT:Available FTL:$1/]
 	[bbloc=#GTT_ALIGNED_STAT:Maximum Storage:$2/]
 	[bbloc=#GTT_ALIGNED_STAT:Generation Rate:$3/]
+
 >>
 
 GTT_RESEARCH: <<
@@ -50,6 +49,7 @@ GTT_RESEARCH: <<
 
 	[bbloc=#GTT_ALIGNED_STAT:Available Research Points:$1/]
 	[bbloc=#GTT_ALIGNED_STAT:Generation Rate:$2/]
+
 >>
 
 GTT_RESEARCH_TECH: <<

--- a/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
+++ b/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
@@ -1,0 +1,624 @@
+import elements.BaseGuiElement;
+import elements.GuiText;
+import elements.GuiTextbox;
+import elements.GuiButton;
+import elements.GuiSprite;
+import elements.GuiMarkupText;
+import elements.GuiContextMenu;
+import elements.GuiProgressbar;
+import elements.MarkupTooltip;
+import targeting.ObjectTarget;
+import resources;
+import research;
+import icons;
+#include "include/resource_constants.as"
+
+import tabs.tabbar;
+from tabs.ResearchTab import createResearchTab;
+from tabs.DiplomacyTab import createDiplomacyTab;
+
+const double UPDATE_INTERVAL = 0.05;
+
+class ResourceDisplay : BaseGuiElement {
+	Color color;
+	GuiSprite@ icon;
+	BaseGuiElement@ value;
+	int padding = 4;
+	MarkupTooltip@ ttip;
+
+	GuiMarkupText@ upperText;
+	GuiMarkupText@ lowerText;
+
+	ResourceDisplay(IGuiElement@ parent, Alignment@ align) {
+		super(parent, align);
+		updateAbsolutePosition();
+		@value = BaseGuiElement(this, recti());
+
+		@ttip = MarkupTooltip("", 320, 0.5f, true, false);
+		ttip.StaticPosition = true;
+		ttip.Lazy = true;
+		ttip.LazyUpdate = true;
+		@tooltipObject = ttip;
+	}
+
+	void addIcon(const Sprite& sprt) {
+		@icon = GuiSprite(this, recti_area(vec2i(), sprt.size));
+		icon.desc = sprt;
+	}
+
+	void addTexts() {
+		@upperText = GuiMarkupText(value, recti());
+		upperText.defaultFont = FT_Medium;
+		upperText.memo = true;
+		@lowerText = GuiMarkupText(value, recti());
+		lowerText.memo = true;
+		lowerText.defaultColor = Color(0xaaaaaaff);
+	}
+
+	int get_baseValueWidth() {
+		return 0;
+	}
+
+	void update() {
+		//Center the elements
+		int width = 0;
+		if(icon !is null)
+			width += icon.size.width + padding;
+
+		if(value !is null) {
+			int valueWidth = this.baseValueWidth;
+			if(upperText !is null) {
+				valueWidth = max(valueWidth, upperText.textWidth);
+				upperText.position = vec2i(0, 1);
+				upperText.size = vec2i(300, size.height/2);
+			}
+			if(lowerText !is null) {
+				valueWidth = max(valueWidth, lowerText.textWidth);
+				lowerText.position = vec2i(2, size.height/2-1);
+				lowerText.size = vec2i(300, size.height/2);
+			}
+			width += valueWidth;
+			value.size = vec2i(valueWidth+padding, size.height);
+		}
+
+		int pos = (size.width - width) / 2;
+		if(icon !is null) {
+			icon.position = vec2i(pos, (size.height - icon.size.height) / 2 - 2);
+			pos += icon.size.width + padding;
+		}
+		if(value !is null) {
+			value.size = vec2i(value.size.width, size.height);
+			value.position = vec2i(pos, 0);
+		}
+	}
+
+	void updateAbsolutePosition() {
+		BaseGuiElement::updateAbsolutePosition();
+		if(value !is null)
+			update();
+		if(ttip !is null) {
+			ttip.width = max(size.width, 250);
+			ttip.offset = absolutePosition.topLeft + vec2i(min(size.width-250,0), size.height);
+		}
+	}
+
+	void draw() {
+		skin.draw(SS_PlainBox, SF_Normal, AbsolutePosition.padded(0,-2,0,1));
+
+		Color topColor = color;
+		topColor.a = 0x30;
+
+		Color botColor = color;
+		botColor.a = 0x10;
+
+		drawRectangle(AbsolutePosition, topColor, topColor, botColor, botColor);
+
+		BaseGuiElement::draw();
+	}
+};
+
+class InfluenceResource : ResourceDisplay {
+	InfluenceResource(IGuiElement@ parent, Alignment@ align) {
+		super(parent, align);
+
+		color = colors::Influence;
+		addIcon(icons::Influence);
+		addTexts();
+	}
+
+	string get_tooltip() {
+		return format(locale::GTT_INFLUENCE,
+				toString(playerEmpire.Influence),
+				toString(playerEmpire.InfluenceCap, 0),
+				formatIncomeRate(playerEmpire.InfluenceIncome, perMinute=true),
+				toString(playerEmpire.InfluencePercentage*100.0, 0)+"%",
+				toString(playerEmpire.getInfluenceStock(), 0));
+	}
+
+	void update() {
+		int influence = playerEmpire.Influence;
+		double income = playerEmpire.InfluenceIncome;
+		double percentage = playerEmpire.InfluencePercentage;
+		double efficiency = playerEmpire.InfluenceEfficiency;
+		int cap = playerEmpire.InfluenceCap;
+
+		Color storedColor = colors::White;
+		if(efficiency < 1.0 - 0.01)
+			storedColor = Color(0xff0000ff).interpolate(storedColor, efficiency);
+
+		upperText.text = format(
+				"[color=$3]$1[/color][color=#aaa][vspace=6][font=Normal]/$2[/font][/vspace][/color]",
+				toString(influence), toString(cap), toString(storedColor));
+
+		lowerText.text = format(
+				"$1 ($2%)",
+				formatIncomeRate(income, perMinute=true), toString(percentage * 100.f, 0));
+		ResourceDisplay::update();
+	}
+};
+
+class EnergyResource : ResourceDisplay {
+	EnergyResource(IGuiElement@ parent, Alignment@ align) {
+		super(parent, align);
+
+		color = colors::Energy;
+		addIcon(icons::Energy);
+		addTexts();
+	}
+
+	string get_tooltip() {
+		double income = playerEmpire.EnergyIncome - playerEmpire.EnergyUse;
+		double factor = playerEmpire.EnergyEfficiency;
+		if(income > 0)
+			income *= factor;
+
+		return format(locale::GTT_ENERGY,
+				toString(playerEmpire.EnergyStored, 0),
+				formatIncomeRate(income),
+				toString(playerEmpire.FreeEnergyStorage, 0),
+				"-"+toString((1.0-factor)*100.0, 0)+"%");
+	}
+
+	void update() {
+		double stored = playerEmpire.EnergyStored;
+		double income = playerEmpire.EnergyIncome - playerEmpire.EnergyUse;
+		double factor = playerEmpire.EnergyEfficiency;
+		if(income > 0)
+			income *= factor;
+
+		upperText.text = toString(stored, 0);
+		lowerText.text = formatIncomeRate(income);
+		ResourceDisplay::update();
+	}
+};
+
+class FTLResource : ResourceDisplay {
+	FTLResource(IGuiElement@ parent, Alignment@ align) {
+		super(parent, align);
+
+		color = colors::FTLResource;
+		addIcon(icons::FTL);
+		addTexts();
+	}
+
+	string get_tooltip() {
+		return format(locale::GTT_FTL,
+				toString(playerEmpire.FTLStored, 0),
+				toString(playerEmpire.FTLCapacity, 0),
+				formatIncomeRate(playerEmpire.FTLIncome - playerEmpire.FTLUse));
+	}
+
+	void update() {
+		double stored = playerEmpire.FTLStored;
+		double income = playerEmpire.FTLIncome - playerEmpire.FTLUse;
+		double capacity = playerEmpire.FTLCapacity;
+
+		upperText.text = format(
+				"$1[color=#aaa][vspace=6][font=Normal]/$2[/font][/vspace][/color]",
+				toString(stored, 0), toString(capacity, 0));
+
+		lowerText.text = formatIncomeRate(income);
+		ResourceDisplay::update();
+	}
+};
+
+class ResearchResource : ResourceDisplay {
+	array<TechnologyNode> researching;
+
+	GuiProgressbar@ techBar;
+	GuiSprite@ techIcon;
+
+	ResearchResource(IGuiElement@ parent, Alignment@ align) {
+		super(parent, align);
+
+		color = colors::Research;
+		addIcon(icons::Research);
+		addTexts();
+
+		@techBar = GuiProgressbar(value, Alignment(Left, Bottom-0.5f+3, Left+100, Bottom-4));
+		techBar.strokeColor = colors::Black;
+		techBar.textHorizAlign = 0.9;
+		@techIcon = GuiSprite(techBar, Alignment(Left+2, Top+0.5f-12, Left+2+24, Top+0.5f+12));
+		techIcon.noClip = true;
+	}
+
+	int get_baseValueWidth() {
+		if(techBar is null || !techBar.visible)
+			return 0;
+		return 100;
+	}
+
+	string get_tooltip() {
+		string tt = format(locale::GTT_RESEARCH,
+				toString(playerEmpire.ResearchPoints, 0),
+				formatIncomeRate(playerEmpire.ResearchRate));
+		for(uint i = 0, cnt = researching.length; i < cnt; ++i) {
+			tt += "\n"+format(locale::GTT_RESEARCH_TECH,
+				researching[i].type.name, formatTime(researching[i].timer),
+				toString(researching[i].type.color));
+		}
+		return tt;
+	}
+
+	void update() {
+		double stored = playerEmpire.ResearchPoints;
+		double income = playerEmpire.ResearchRate;
+
+		upperText.text = toString(stored, 0);
+		lowerText.text = formatIncomeRate(income);
+
+		researching.syncFrom(playerEmpire.getResearchingNodes());
+		if(researching.length != 0) {
+			researching.sortAsc();
+
+			techBar.visible = true;
+			lowerText.visible = false;
+
+			auto@ activeTech = researching[0];
+			techBar.text = formatTime(activeTech.timer);
+			techIcon.desc = activeTech.type.icon;
+			techBar.frontColor = activeTech.type.color;
+			techBar.textColor = activeTech.type.color.interpolate(colors::White, 0.75f);
+			techBar.progress = 1.0 - (activeTech.timer / activeTech.getTimeCost(playerEmpire));
+		}
+		else {
+			techBar.visible = false;
+			lowerText.visible = true;
+		}
+
+		ResourceDisplay::update();
+	}
+};
+
+class ChangeWelfare : GuiContextOption {
+	ChangeWelfare(const string& text, uint index) {
+		value = int(index);
+		this.text = text;
+		icon = Sprite(spritesheet::ConvertIcon, index);
+	}
+
+	void call(GuiContextMenu@ menu) override {
+		playerEmpire.WelfareMode = uint(value);
+	}
+};
+
+class BudgetResource : ResourceDisplay {
+	array<TechnologyNode> researching;
+
+	GuiProgressbar@ cycleBar;
+
+	GuiButton@ welfareButton;
+	GuiSprite@ welfareIcon;
+
+	GuiText@ nextBudget;
+
+	BudgetResource(IGuiElement@ parent, Alignment@ align) {
+		super(parent, align);
+
+		color = colors::Money;
+		addIcon(icons::Money);
+		addTexts();
+
+		@cycleBar = GuiProgressbar(value, Alignment(Left, Bottom-0.5f+3, Left+120, Bottom-4));
+		cycleBar.font = FT_Small;
+		
+		@nextBudget = GuiText(value, Alignment(Left+120, Bottom-0.5f+1, Left+200, Bottom-1));
+		nextBudget.horizAlign = 0.5;
+
+		@welfareButton = GuiButton(value, Alignment(Right-84+40-25, Top, Width=50, Height=24));
+		@welfareIcon = GuiSprite(welfareButton, Alignment(Left+8, Top-5, Right-8, Bottom+5),
+				Sprite(spritesheet::ConvertIcon, 0));
+
+		setMarkupTooltip(welfareButton, locale::WELFARE_TT, hoverStyle=false);
+	}
+
+	int get_baseValueWidth() {
+		return 200;
+	}
+
+	string get_tooltip() {
+		string tt = format(locale::GTT_MONEY,
+				formatMoneyChange(playerEmpire.RemainingBudget, colored=true),
+				formatMoneyChange(playerEmpire.EstNextBudget, colored=true),
+				formatTime(playerEmpire.BudgetCycle - playerEmpire.BudgetTimer),
+				getSpriteDesc(welfareIcon.desc));
+		tt += format("\n[font=Medium]$1[/font]\n", locale::RESOURCE_BUDGET);
+		for(int i = MoT_COUNT - 1; i >= 0; --i) {
+			int money = playerEmpire.getMoneyFromType(i);
+			if(money != 0) {
+				tt += format("$1: [right]$2[/right]",
+					localize("MONEY_TYPE_"+i), formatMoneyChange(money, true));
+			}
+		}
+
+		int bonusMoney = playerEmpire.BonusBudget;
+		if(bonusMoney != 0)
+			tt += "\n\n"+format(locale::GTT_BONUS_MONEY, formatMoney(bonusMoney));
+
+		float debtFactor = playerEmpire.DebtFactor;
+		if(debtFactor > 1.f) {
+			float effFactor = pow(0.5f, debtFactor-1.f);
+			tt += "\n\n"+format(locale::GTT_FLEET_PENALTY, "-"+toString((1.f - effFactor)*100.f, 0)+"%");
+		}
+		if(debtFactor > 0.f) {
+			float growthFactor = 1.f;
+			for(; debtFactor > 0; debtFactor -= 1.f)
+				growthFactor *= 0.33f + 0.67f * (1.f - min(debtFactor, 1.f));
+			tt += "\n\n"+format(locale::GTT_DEBT_PENALTY, "-"+toString((1.f - growthFactor)*100.f, 0)+"%");
+		}
+		return tt;
+	}
+
+	bool onGuiEvent(const GuiEvent& evt) override {
+		if(evt.caller is welfareButton && evt.type == GUI_Clicked) {
+			GuiContextMenu menu(mousePos);
+			menu.itemHeight = 54;
+			string money = formatMoney(350.0 / playerEmpire.WelfareEfficiency);
+			menu.addOption(ChangeWelfare(format(locale::WELFARE_INFLUENCE, money), 0));
+			menu.addOption(ChangeWelfare(format(locale::WELFARE_ENERGY, money), 1));
+			menu.addOption(ChangeWelfare(format(locale::WELFARE_RESEARCH, money), 2));
+			menu.addOption(ChangeWelfare(format(locale::WELFARE_LABOR, money), 3));
+			menu.addOption(ChangeWelfare(format(locale::WELFARE_DEFENSE, money), 4));
+			menu.updateAbsolutePosition();
+			return true;
+		}
+		return ResourceDisplay::onGuiEvent(evt);
+	}
+
+	void update() {
+		//NOTE: Maybe related to spectating?
+		if(playerEmpire is null)
+			return;
+		
+		//Current budget
+		int curBudget = playerEmpire.RemainingBudget;
+		int bonusBudget = playerEmpire.BonusBudget;
+
+		Color color(0xffffffff);
+		if(curBudget < 0)
+			color = Color(0xff0000ff);
+		else if(curBudget - bonusBudget < 0)
+			color = Color(0xff8000ff);
+		else
+			color = Color(0xffffffff);
+
+		upperText.defaultColor = color;
+		upperText.text = formatMoney(curBudget, roundUp=false);
+
+		welfareIcon.desc = Sprite(spritesheet::ConvertIcon, playerEmpire.WelfareMode);
+
+		//Cycle timer
+		double cycle = playerEmpire.BudgetCycle;
+		double timer = playerEmpire.BudgetTimer;
+
+		cycleBar.text = formatTime(cycle - timer);
+		if(cycle == 0)
+			cycleBar.progress = 0.f;
+		else
+			cycleBar.progress = timer / cycle;
+
+		if(cycleBar.progress < (1.0 / 3.0))
+			cycleBar.frontColor = colors::Money;
+		else if(cycleBar.progress < (2.0 / 3.0))
+			cycleBar.frontColor = colors::Money.interpolate(colors::Red, 0.3);
+		else
+			cycleBar.frontColor = colors::Money.interpolate(colors::Red, 0.6);
+
+		//Next budget
+		int upcoming = playerEmpire.EstNextBudget;
+		if(upcoming < 0)
+			nextBudget.color = Color(0xbb0000ff);
+		else
+			nextBudget.color = Color(0xbbbbbbff);
+		nextBudget.text = formatMoney(upcoming);
+
+		ResourceDisplay::update();
+	}
+};
+
+class DeployTarget : ObjectTargeting {
+	DeployTarget() {
+		icon = icons::Defense;
+	}
+
+	void call(Object@ target) {
+		playerEmpire.deployDefense(target);
+	}
+
+	string message(Object@ obj, bool valid) {
+		return locale::TT_DEPLOY;
+	}
+
+	bool valid(Object@ obj) {
+		if(!obj.isPlanet)
+			return false;
+		return obj.owner !is null && obj.owner.valid;
+	}
+};
+
+class DefenseResource : ResourceDisplay {
+	GuiProgressbar@ bar;
+	GuiButton@ button;
+
+	DefenseResource(IGuiElement@ parent, Alignment@ align) {
+		super(parent, align);
+
+		color = colors::Defense;
+		addIcon(icons::Defense);
+		addTexts();
+
+		@bar = GuiProgressbar(value, Alignment(Left, Bottom-0.5f+3, Left+100, Bottom-4));
+		bar.frontColor = colors::Defense;
+		bar.font = FT_Small;
+		bar.visible = false;
+
+		@button = GuiButton(value, Alignment(Left+70, Top+2, Left+100, Top+28));
+		GuiSprite(button, Alignment().padded(-2), icons::Strength);
+		button.visible = false;
+		setMarkupTooltip(button, locale::TT_DEPLOY);
+	}
+
+	string get_tooltip() {
+		return format(locale::GTT_DEFENSE,
+				standardize(playerEmpire.globalDefenseRate * 60.0 / DEFENSE_LABOR_PM, true)+locale::PER_MINUTE,
+				standardize(playerEmpire.globalDefenseStorage, true),
+				standardize(playerEmpire.globalDefenseStored, true));
+	}
+
+	int get_baseValueWidth() {
+		return bar.visible ? 100 : 0;
+	}
+
+	bool onGuiEvent(const GuiEvent& evt) override {
+		if(evt.caller is button && evt.type == GUI_Clicked) {
+			targetObject(DeployTarget());
+			return true;
+		}
+		return ResourceDisplay::onGuiEvent(evt);
+	}
+
+	void update() {
+		double income = playerEmpire.globalDefenseRate / DEFENSE_LABOR_PM;
+		upperText.text = format(
+				"$1[color=#aaa][vspace=6][font=Normal]$2[/font][/vspace][/color]",
+				toString(income * 60.0, 0), locale::PER_MINUTE);
+		ResourceDisplay::update();
+
+		double storage = playerEmpire.globalDefenseStorage;
+		double stored = playerEmpire.globalDefenseStored;
+
+		if(storage == 0) {
+			upperText.position = vec2i(0, 8);
+			bar.visible = false;
+			button.visible = false;
+		}
+		else {
+			upperText.position = vec2i(0, 1);
+			bar.text = standardize(floor(stored), true)+" / "+standardize(storage, true);
+			bar.progress= stored / storage;
+			bar.visible = true;
+			button.visible = stored >= storage*0.9999;
+		}
+	}
+};
+
+class GlobalBar : BaseGuiElement {
+	BaseGuiElement@ container;
+	double updateTimer = -INFINITY;
+
+	array<ResourceDisplay@> sections;
+	ResourceDisplay@ budget;
+	ResourceDisplay@ energy;
+	ResourceDisplay@ ftl;
+	ResourceDisplay@ influence;
+	ResourceDisplay@ research;
+	ResourceDisplay@ defense;
+
+	GlobalBar() {
+		super(null, recti());
+
+		@container = BaseGuiElement(this, Alignment_Fill());
+		container.StrictBounds = true;
+
+		@budget = BudgetResource(container, Alignment());
+		sections.insertLast(budget);
+
+		@influence = InfluenceResource(container, Alignment());
+		sections.insertLast(influence);
+
+		@energy = EnergyResource(container, Alignment());
+		sections.insertLast(energy);
+
+		@ftl = FTLResource(container, Alignment());
+		sections.insertLast(ftl);
+
+		@research = ResearchResource(container, Alignment());
+		sections.insertLast(research);
+
+		@defense = DefenseResource(container, Alignment());
+		sections.insertLast(defense);
+		
+		updateSections();
+	}
+
+	void update() {
+		for(uint i = 0, cnt = sections.length; i < cnt; ++i)
+			sections[i].update();
+	}
+
+	void updateSections(){ 
+		float x = 0.f;
+		for(uint i = 0, cnt = sections.length; i < cnt; ++i) {
+			float w;
+			if(size.width >= 1600)
+				w = 1.f / 6.f;
+			else if(i == 0)
+				w = 1.f / 5.f;
+			else
+				w = (1.f - (1.f / 5.f)) / 5.f;
+
+			sections[i].alignment = Alignment(Left+x, Top, Left+x+w, Bottom);
+			x += w;
+		}
+		updateAbsolutePosition();
+	}
+
+	void updateAbsolutePosition() {
+		int width = AbsolutePosition.width;
+		BaseGuiElement::updateAbsolutePosition();
+		if(width != AbsolutePosition.width)
+			updateSections();
+	}
+
+	void draw() {
+		if(frameTime - UPDATE_INTERVAL >= updateTimer) {
+			update();
+			updateTimer = frameTime;
+		}
+
+		skin.draw(SS_GlobalBar, SF_Normal, AbsolutePosition);
+		BaseGuiElement::draw();
+	}
+}
+
+BaseGuiElement@ createGlobalBar() {
+	return GlobalBar();
+}
+
+void preReload(Message& msg) {
+	globalBar.remove();
+}
+
+void postReload(Message& msg) {
+	@globalBar = GlobalBar();
+	@globalBar.alignment = Alignment(Left, Top+TAB_HEIGHT + 2, Right, Top+TAB_HEIGHT + 2 + GLOBAL_BAR_HEIGHT);
+}
+
+void deploy_defense(bool pressed) {
+	if(pressed)
+		targetObject(DeployTarget());
+}
+
+void init() {
+	keybinds::Global.addBind(KB_DEPLOY_DEFENSE, "deploy_defense");
+}

--- a/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
+++ b/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
@@ -342,11 +342,11 @@ class BudgetResource : ResourceDisplay {
 				formatMoneyChange(playerEmpire.EstNextBudget, colored=true),
 				formatTime(playerEmpire.BudgetCycle - playerEmpire.BudgetTimer),
 				getSpriteDesc(welfareIcon.desc));
-		tt += format("\n[font=Medium]$1[/font]\n", locale::RESOURCE_BUDGET);
+		tt += format("\n[font=Medium]$1[/font]\n\n", locale::RESOURCE_BUDGET);
 		for(int i = MoT_COUNT - 1; i >= 0; --i) {
 			int money = playerEmpire.getMoneyFromType(i);
 			if(money != 0) {
-				tt += format("$1: [right]$2[/right]",
+				tt += format("$1: [vspace=-16/][right]$2[/right][hr=#333/]",
 					localize("MONEY_TYPE_"+i), formatMoneyChange(money, true));
 			}
 		}

--- a/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
+++ b/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
@@ -342,11 +342,11 @@ class BudgetResource : ResourceDisplay {
 				formatMoneyChange(playerEmpire.EstNextBudget, colored=true),
 				formatTime(playerEmpire.BudgetCycle - playerEmpire.BudgetTimer),
 				getSpriteDesc(welfareIcon.desc));
-		tt += format("\n[font=Medium]$1[/font]\n\n", locale::RESOURCE_BUDGET);
+		tt += format("\n\n[font=Medium]$1[/font]\n\n", locale::RESOURCE_BUDGET);
 		for(int i = MoT_COUNT - 1; i >= 0; --i) {
 			int money = playerEmpire.getMoneyFromType(i);
 			if(money != 0) {
-				tt += format(locale::GTT_ALIGNED_STAT, localize("MONEY_TYPE_"+i), formatMoneyChange(money, true));
+				tt += format(locale::GTT_ALIGNED_STAT, localize("MONEY_TYPE_"+i), formatMoneyChange(money, true)) + "[nl/]\n";
 			}
 		}
 

--- a/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
+++ b/SR2 Community Patch/scripts/gui/tabs/GlobalBar.as
@@ -346,8 +346,7 @@ class BudgetResource : ResourceDisplay {
 		for(int i = MoT_COUNT - 1; i >= 0; --i) {
 			int money = playerEmpire.getMoneyFromType(i);
 			if(money != 0) {
-				tt += format("$1: [vspace=-16/][right]$2[/right][hr=#333/]",
-					localize("MONEY_TYPE_"+i), formatMoneyChange(money, true));
+				tt += format(locale::GTT_ALIGNED_STAT, localize("MONEY_TYPE_"+i), formatMoneyChange(money, true));
 			}
 		}
 

--- a/SR2 Community Patch/scripts/toolkit/elements/GuiMarkupText.as
+++ b/SR2 Community Patch/scripts/toolkit/elements/GuiMarkupText.as
@@ -1,0 +1,1383 @@
+import elements.BaseGuiElement;
+import elements.GuiPanel;
+import util.formatting;
+
+#section game
+from hooks import Targets, TargetType;
+import orbitals;
+import buildings;
+import resources;
+import void drawResource(const ResourceType@ type, const recti& pos) from "elements.GuiResources";
+import void drawSmallResource(const ResourceType@ type, const Resource@ r, const recti& pos, Object@ drawFrom = null, bool onPlanet = false) from "elements.GuiResources";
+import void drawObjectIcon(Object@ obj, const recti& pos) from "util.icon_view";
+#section all
+
+from gui import gui_root;
+
+export MarkupRenderer, GuiMarkupText;
+
+const Color LINK_COLOR(0x98bbf5ff);
+const Color LINK_HOVER_BG(0xffffff20);
+const string strSemicolon(";"), NO_ANCHOR("");
+const string PAR_SEP("\r");
+const string LINE_SEP("\n");
+
+enum TagType {
+	TT_Text,
+	TT_Font,
+	TT_Color,
+	TT_Stroke,
+	TT_SkinColor,
+	TT_HSpace,
+	TT_VSpace,
+	TT_VBlock,
+	TT_Offset,
+	TT_Padding,
+	TT_Locale,
+	TT_Bold,
+	TT_Italic,
+	TT_BR,
+	TT_NL,
+	TT_Data,
+	TT_DLC
+};
+
+enum MarkupMode {
+	MM_Draw,
+	MM_Layout,
+};
+
+class MarkupData {
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) {
+	}
+
+	bool contains(const Skin@ skin, MarkupState@ state, const vec2i& pos) {
+		return false;
+	}
+
+	void set_hovered(bool value) {
+	}
+
+	string get_tooltip() {
+		return "";
+	}
+
+	const string& get_anchor() {
+		return NO_ANCHOR;
+	}
+
+	int get_anchorPosition() {
+		return -1;
+	}
+
+	bool onClick(GuiMarkupText@ elem, int button, bool pressed) {
+		return false;
+	}
+};
+
+final class MarkupObjectIcon : MarkupData {
+	uint objId;
+	vec2i size;
+	int offset;
+
+#section game
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		state.checkLine(size.x);
+		if(mode == MM_Draw) {
+			auto@ obj = getObjectByID(objId);
+			if(obj !is null)
+				drawObjectIcon(obj, recti_area(state.pos + vec2i(0, offset), size));
+		}
+		state.pos.x += size.x;
+
+		if(tag.childCount > 0) {
+			int prevPos = state.area.topLeft.x;
+			state.area.topLeft.x = state.pos.x + 14;
+			state.pos.x = state.area.topLeft.x;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.area.topLeft.x = prevPos;
+			state.linebreak();
+		}
+		else {
+			if(size.y+offset*2 > state.lineHeight)
+				state.lineHeight = size.y+offset*2;
+		}
+	}
+#section all
+};
+
+final class MarkupImage : MarkupData {
+	Sprite spr;
+	Color color;
+	vec2i size;
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		state.checkLine(size.x);
+		if(mode == MM_Draw)
+			spr.draw(recti_area(state.pos, size), color);
+		state.pos.x += size.x;
+
+		if(tag.childCount > 0) {
+			int prevPos = state.area.topLeft.x;
+			state.area.topLeft.x = state.pos.x + 14;
+			state.pos.x = state.area.topLeft.x;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.area.topLeft.x = prevPos;
+			state.linebreak();
+		}
+		else {
+			if(size.y > state.lineHeight)
+				state.lineHeight = size.y;
+		}
+	}
+};
+
+final class MarkupAlign : MarkupData {
+	double align = 0.5;
+	double width = -1;
+	double widthSpec = -1;
+	int loffset = 0;
+	int roffset = 0;
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		if(mode == MM_Draw) {
+			state.clearLine();
+			int startPos = state.pos.x;
+			state.area.topLeft.x += loffset;
+			state.area.botRight.x -= roffset;
+			state.pos.x += loffset;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.clearLine();
+			state.area.topLeft.x -= loffset;
+			state.area.botRight.x += roffset;
+			state.pos.x = startPos+width;
+			state.linebreak();
+		}
+		else if(mode == MM_Layout) {
+			state.clearLine();
+			if(widthSpec <= 0)
+				width = state.area.width;
+			else if(widthSpec <= 1)
+				width = double(state.area.width) * widthSpec;
+
+			vec2i start = state.pos;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			vec2i end = state.pos;
+
+			double diff = double(width) - double(end.x - start.x);
+			loffset = diff * align;
+			roffset = diff * (1.0 - align);
+
+			state.pos = start;
+			state.area.topLeft.x += loffset;
+			state.area.botRight.x -= roffset;
+			state.pos.x += loffset;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.clearLine();
+			state.area.topLeft.x -= loffset;
+			state.area.botRight.x += roffset;
+			state.pos.x = start.x+width;
+			state.linebreak();
+		}
+	}
+};
+
+final class MarkupLine : MarkupData {
+	Color color(0xaaaaaaff);
+	int width = 1;
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		state.checkLine(state.area.width - 1);
+		if(mode == MM_Draw)
+			drawRectangle(recti_area(state.pos+vec2i(0, 3), vec2i(state.area.width - 12, width)), color);
+		state.pos.y += 8;
+	}
+};
+
+const array<FontType> HeadingFonts = {FT_Medium, FT_Subtitle, FT_Bold};
+const array<uint> HeadingOffsets = {16, 10, 0};
+final class MarkupHeading : MarkupData {
+	string name;
+	FontType font;
+	int position = 0;
+	int offset;
+
+	MarkupHeading(uint level, BBTag@ tag) {
+		font = HeadingFonts[clamp(level-1, 0, 2)];
+		offset = HeadingOffsets[clamp(level-1, 0, 2)];
+		bbToPlainText(tag, name);
+	}
+
+	const string& get_anchor() {
+		return name;
+	}
+
+	int get_anchorPosition() {
+		return position;
+	}
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		if(state.pos.y > state.area.topLeft.y)
+			state.pos.y += offset;
+		const Font@ prev = state.font;
+		@state.font = skin.getFont(font);
+		position = state.pos.y - state.absArea.topLeft.y;
+		for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+			markupComp(skin, state, tag.children[i], mode);
+		@state.font = prev;
+		state.linebreak();
+	}
+};
+
+final class MarkupLink : MarkupData {
+	string link;
+	string text;
+	recti relPos;
+	bool Hovered = false;
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		if(mode == MM_Draw) {
+			state.checkLine(relPos.width);
+			state.lineHeight = max(state.lineHeight, state.font.getLineHeight());
+
+			if(Hovered)
+				drawRectangle(relPos.padded(-2) + state.absArea.topLeft, LINK_HOVER_BG);
+			state.font.draw(relPos + state.absArea.topLeft,
+					text, locale::ELLIPSIS, LINK_COLOR, 0.0, 0.5);
+			state.pos.x += relPos.width;
+		}
+		else if(mode == MM_Layout) {
+			state.lineHeight = max(state.lineHeight, state.font.getLineHeight());
+
+			vec2i dim = state.font.getDimension(text);
+			dim.y = state.lineHeight;
+			relPos = recti_area(state.pos - state.absArea.topLeft, dim);
+			state.pos.x += relPos.width;
+
+			state.checkLine(relPos.width);
+		}
+	}
+
+	bool contains(const Skin@ skin, MarkupState@ state, const vec2i& pos) override {
+		return relPos.contains(pos - state.absArea.topLeft);
+	}
+
+	void set_hovered(bool value) override {
+		Hovered = value;
+	}
+
+	bool onClick(GuiMarkupText@ elem, int button, bool pressed) override {
+		if(!pressed)
+			elem.onLinkClicked(link, button);
+		return true;
+	}
+};
+
+class MarkupGuiElement : MarkupData {
+	IGuiElement@ element;
+
+	MarkupGuiElement(IGuiElement@ elem) {
+		@element = elem;
+		@element.parent = gui_root;
+	}
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		vec2i size = element.size;
+		state.checkLine(size.width);
+		state.lineHeight = max(state.lineHeight, size.height);
+		element.position = state.pos;
+	}
+};
+
+final class MarkupTemplate : MarkupData {
+	BBCode code;
+
+	MarkupTemplate(const string& text, MarkupState@ state) {
+		code.parse(text);
+
+		BBTag@ root = code.root;
+		for(uint i = 0, cnt = root.childCount; i < cnt; ++i) {
+			BBTag@ tag = root.children[i];
+			markupParse(tag, state);
+		}
+	}
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		BBTag@ root = code.root;
+		for(uint i = 0, cnt = root.childCount; i < cnt; ++i)
+			markupComp(skin, state, root.children[i], mode);
+	}
+};
+
+class MarkupReference : MarkupData {
+	Sprite icon;
+	string name;
+	string ttip;
+	recti relPos;
+	Color background(0x00000000);
+	int refSize = -1;
+
+	MarkupReference() {
+	}
+
+	MarkupReference(const Sprite& sprt, const string& tip) {
+		icon = sprt;
+		ttip = tip;
+	}
+
+	MarkupReference(const Sprite& sprt, const string& tip, const string& txt, const Color& bg, int sz = -1) {
+		icon = sprt;
+		ttip = tip;
+		name = txt;
+		background = bg;
+		refSize = sz;
+	}
+
+	string get_tooltip() {
+		return ttip;
+	}
+
+	bool contains(const Skin@ skin, MarkupState@ state, const vec2i& pos) override {
+		return relPos.contains(pos - state.absArea.topLeft);
+	}
+
+	void drawIcon(const recti& pos) {
+		icon.draw(pos);
+	}
+
+	void comp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) override {
+		vec2i isize = icon.size;
+		if(refSize != -1)
+			isize = vec2i(int(double(refSize) * icon.aspect), refSize);
+		else if(isize.y == 0)
+			isize.y = 22;
+
+		vec2i size = isize;
+		vec2i tsize;
+		if(name.length != 0) {
+			tsize = state.font.getDimension(name);
+			size.x += tsize.x + 8;
+		}
+
+		state.checkLine(size.x);
+		if(mode == MM_Draw) {
+			if(background.a != 0)
+				drawRectangle(recti_area(state.pos, size), background);
+			drawIcon(recti_area(state.pos, isize));
+			if(name.length != 0) {
+				int yOff = (state.font.getLineHeight() - state.font.getBaseline()) / 2;
+				yOff += (isize.y-(tsize.y+yOff))/2;
+				state.font.draw(state.pos + vec2i(isize.x+4, yOff), name, state.color);
+			}
+		}
+		relPos = recti_area(state.pos - state.absArea.topLeft, size);
+		if(size.y > state.lineHeight)
+			state.lineHeight = size.y;
+		state.pos.x += size.x;
+	}
+};
+
+#section game
+class MarkupLargeResource : MarkupReference {
+	const ResourceType@ resource;
+
+	MarkupLargeResource(const ResourceType& type) {
+		@resource = type;
+		icon = type.icon;
+		name = type.name;
+		ttip = getResourceTooltip(type);
+		background = Color(0xffffff10);
+	}
+
+	void drawIcon(const recti& pos) override {
+		drawResource(resource, pos);
+	}
+};
+
+class MarkupSmallResource : MarkupReference {
+	const ResourceType@ resource;
+
+	MarkupSmallResource(const ResourceType& type) {
+		@resource = type;
+		icon = type.smallIcon;
+		name = type.name;
+		ttip = getResourceTooltip(type);
+		background = Color(0xffffff10);
+	}
+
+	void drawIcon(const recti& pos) override {
+		drawSmallResource(resource, null, pos);
+	}
+};
+#section all
+
+final class MarkupState {
+	bool expandWidth = false;
+	bool paragraphize = false;
+	recti absArea;
+	recti area;
+	vec2i pos;
+	const Font@ font;
+	Color color;
+	Color stroke;
+	int lineHeight;
+	int maxWidth = 0;
+	bool wasPrintable = false;
+	MarkupData@ contains;
+	MarkupData@[] data;
+
+#section game
+	Targets@ targets;
+#section all
+
+	void checkLine(int width) {
+		if(pos.x + width > area.botRight.x)
+			linebreak();
+	}
+
+	int getLineHeight() {
+		return max(font.getLineHeight(), lineHeight);
+	}
+
+	void linebreak() {
+		maxWidth = max(maxWidth, pos.x - absArea.topLeft.x);
+		pos.x = area.topLeft.x;
+		pos.y += max(font.getLineHeight(), lineHeight);
+		lineHeight = -1;
+	}
+
+	void clearLine() {
+		if(pos.x > area.topLeft.x)
+			linebreak();
+	}
+
+	void reset(const Skin@ skin, const recti& Area, FontType defaultFont, const Color& defaultColor, const Color& defaultStroke) {
+		area = Area;
+		absArea = Area;
+		pos = area.topLeft;
+		@font = skin.getFont(defaultFont);
+		color = defaultColor;
+		stroke = defaultStroke;
+		lineHeight = 0;
+		maxWidth = 0;
+	}
+};
+
+//The parse step pre-calculates values for quick drawing
+void markupParse(BBTag@ tag, MarkupState@ state){
+	bool setUnprintable = false;
+	if(tag.type == -1) {
+		tag.type = TT_Text;
+		if(state.paragraphize) {
+			tag.argument.paragraphize(PAR_SEP, LINE_SEP, !state.wasPrintable);
+			state.wasPrintable = !tag.argument.isWhitespace();
+		}
+	}
+	else if(tag.name == "font") {
+		tag.type = TT_Font;
+		tag.value = getFontType(tag.argument);
+	}
+	else if(tag.name == "h1") {
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(MarkupHeading(1, tag));
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "h2") {
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(MarkupHeading(2, tag));
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "h3") {
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(MarkupHeading(3, tag));
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "br") {
+		tag.type = TT_BR;
+		state.wasPrintable = false;
+	}
+	else if(tag.name == "nl") {
+		tag.type = TT_NL;
+		state.wasPrintable = false;
+	}
+	else if(tag.name == "color") {
+		if(tag.argument.length > 0 && tag.argument[0] == '#') {
+			tag.type = TT_Color;
+			tag.value = toColor(tag.argument).color;
+		}
+		else if(tag.argument.length > 0 && tag.argument[0] == '$') {
+			tag.type = TT_Color;
+			tag.value = getGlobalColor("icons", "colors::"+tag.argument.substr(1)).color;
+		}
+		else {
+			tag.type = TT_SkinColor;
+			tag.value = getColorType(tag.argument);
+		}
+	}
+	else if(tag.name == "stroke") {
+		if(tag.argument.length > 0 && tag.argument[0] == '#') {
+			tag.type = TT_Stroke;
+			tag.value = toColor(tag.argument).color;
+		}
+		else if(tag.argument.length > 0 && tag.argument[0] == '$') {
+			tag.type = TT_Stroke;
+			tag.value = getGlobalColor("icons", "colors::"+tag.argument.substr(1)).color;
+		}
+	}
+	else if(tag.name == "hspace") {
+		tag.type = TT_HSpace;
+		tag.value = toInt(tag.argument);
+		state.wasPrintable = false;
+	}
+	else if(tag.name == "vspace") {
+		tag.type = TT_VSpace;
+		tag.value = toInt(tag.argument);
+		state.wasPrintable = false;
+	}
+	else if(tag.name == "vblock") {
+		tag.type = TT_VBlock;
+		tag.value = toInt(tag.argument);
+	}
+	else if(tag.name == "offset") {
+		tag.type = TT_Offset;
+		tag.value = toInt(tag.argument);
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "padding") {
+		tag.type = TT_Padding;
+		tag.value = toInt(tag.argument);
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "bbloc") {
+		tag.type = TT_Data;
+		state.data.insertLast(MarkupTemplate(localize(tag.argument), state));
+		tag.value = state.data.length-1; //Because MarkupTemplate can add to state.data list
+
+		state.wasPrintable = true;
+	}
+	else if(tag.name == "loc") {
+		tag.type = TT_Text;
+
+		string[] args;
+		args = tag.argument.split(strSemicolon);
+
+		switch(args.length) {
+			case 1:
+				tag.argument = localize(args[0]);
+			break;
+			case 2:
+				tag.argument = format(localize(args[0]), localize(args[1]));
+			break;
+			case 3:
+				tag.argument = format(localize(args[0]), localize(args[1]), localize(args[2]));
+			break;
+			case 4:
+				tag.argument = format(localize(args[0]), localize(args[1]), localize(args[2]), localize(args[3]));
+			break;
+			case 5:
+				tag.argument = format(localize(args[0]), localize(args[1]), localize(args[2]), localize(args[3]), localize(args[4]));
+			break;
+			default:
+				throw("Error parsing bbcode: [loc] tag can have no more than 5 arguments.");
+			break;
+		}
+		state.wasPrintable = true;
+	}
+	else if(tag.name == "b") {
+		tag.type = TT_Bold;
+	}
+	else if(tag.name == "i") {
+		tag.type = TT_Italic;
+	}
+	else if(tag.name == "sprite" || tag.name == "img") {
+		string[] args = tag.argument.split(strSemicolon);
+
+		MarkupImage img;
+		if(args.length != 0) {
+			uint argi = 0;
+			if(tag.name == "sprite") {
+				@img.spr.sheet = getSpriteSheet(args[argi]);
+				++argi;
+
+				if(args.length > argi) {
+					img.spr.index = toUInt(args[argi]);
+					++argi;
+				}
+				img.size = img.spr.size;
+			}
+			else {
+				if(args[argi].length != 0 && args[argi][0] == '$') {
+					img.spr = getGlobalSprite("icons", "icons::"+args[argi].substr(1));
+					img.size = img.spr.size;
+					++argi;
+				}
+				else {
+					img.spr = getSprite(args[argi]);
+					img.size = img.spr.size;
+					++argi;
+				}
+			}
+
+			if(args.length > argi) {
+				string[] parts = args[argi].split("x");
+				int w = 0, h = 0;
+
+				if(parts.length >= 1)
+					w = toInt(parts[0]);
+				if(parts.length >= 2)
+					h = toInt(parts[1]);
+
+				if(w != 0 || h != 0) {
+					if(w == 0)
+						w = double(h) * (double(img.size.x) / double(img.size.y));
+					else if(h == 0)
+						h = double(w) * (double(img.size.y) / double(img.size.x));
+
+					img.size.x = w;
+					img.size.y = h;
+				}
+			}
+			++argi;
+
+			if(args.length > argi)
+				img.color = toColor(args[argi]);
+		}
+
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(img);
+		state.wasPrintable = true;
+	}
+	else if(tag.name == "obj_icon") {
+		string[] args = tag.argument.split(strSemicolon);
+
+		if(args.length == 0)
+			throw("Error parsing bbcode: [obj_icon] tag need arguments.");
+
+		MarkupObjectIcon img;
+		uint argi = 0;
+		img.objId = toInt(args[argi]);
+		img.size = vec2i(30);
+		img.offset = -4;
+		++argi;
+
+		if(args.length > argi) {
+			string[] parts = args[argi].split("x");
+			int w = 0, h = 0;
+
+			if(parts.length >= 1)
+				w = toInt(parts[0]);
+			if(parts.length >= 2)
+				h = toInt(parts[1]);
+
+			if(w != 0 || h != 0) {
+				if(w == 0)
+					w = double(h) * (double(img.size.x) / double(img.size.y));
+				else if(h == 0)
+					h = double(w) * (double(img.size.y) / double(img.size.x));
+
+				img.size.x = w;
+				img.size.y = h;
+			}
+		}
+		++argi;
+
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(img);
+		state.wasPrintable = true;
+	}
+	else if(tag.name == "align") {
+		MarkupAlign dat;
+		int found = tag.argument.findFirst(strSemicolon);
+		if(found == -1) {
+			dat.align = toDouble(tag.argument);
+			dat.widthSpec = -1;
+		}
+		else {
+			dat.align = toDouble(tag.argument.substr(0, found));
+			dat.widthSpec = toDouble(tag.argument.substr(found+1, tag.argument.length - found - 1));
+		}
+
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(dat);
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "center") {
+		MarkupAlign dat;
+		dat.align = 0.5;
+
+		if(tag.argument.length != 0)
+			dat.width = toDouble(tag.argument);
+
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(dat);
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "right") {
+		MarkupAlign dat;
+		dat.align = 1.0;
+
+		if(tag.argument.length != 0)
+			dat.width = toDouble(tag.argument);
+
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(dat);
+		state.wasPrintable = false;
+		setUnprintable = true;
+	}
+	else if(tag.name == "hr") {
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(MarkupLine());
+		state.wasPrintable = false;
+	}
+	else if(tag.name == "levels") {
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.wasPrintable = true;
+
+		string text;
+		if(tag.childCount != 0)
+			text = tag.children[0].argument;
+
+		auto@ levs = text.split("/");
+		auto@ args = tag.argument.split(";");
+		int num = -1;
+		if(args.length >= 1 && args[0].length != 0 && args[0][0] != '$')
+			num = toInt(args[0]);
+
+		text = "";
+		for(uint i = 0, cnt = levs.length; i < cnt; ++i) {
+			if(i != 0)
+				text += "/";
+			if(num == int(i)) {
+				text += "[b]";
+				if(args.length >= 2)
+					text += format("[color=$1]", args[1]);
+			}
+			text += levs[i];
+			if(num == int(i)) {
+				if(args.length >= 2)
+					text += "[/color]";
+				text += "[/b]";
+			}
+		}
+
+		state.data.insertLast(MarkupTemplate(text, state));
+	}
+	else if(tag.name == "dlc") {
+		tag.type = TT_DLC;
+	}
+#section game
+	else if(tag.name == "target") {
+		int found = tag.argument.findFirst(strSemicolon);
+		string type, arg;
+
+		if(found == -1) {
+			arg = tag.argument;
+		}
+		else {
+			type = tag.argument.substr(0, found);
+			arg = tag.argument.substr(found+1, tag.argument.length - found - 1);
+		}
+
+		Target@ targ;
+		if(state.targets !is null)
+			@targ = state.targets.get(arg);
+
+		MarkupData@ dat;
+		if(targ !is null) {
+			if(targ.type == TT_Object && targ.obj !is null) {
+				@dat = MarkupTemplate(formatObject(targ.obj, showIcon = true), state);
+			}
+			else if(targ.type == TT_Empire && targ.emp !is null) {
+				if(type.equals_nocase("race"))
+					@dat = MarkupTemplate(targ.emp.RaceName, state);
+				else
+					@dat = MarkupTemplate(formatEmpireName(targ.emp), state);
+			}
+		}
+		if(dat is null)
+			@dat = MarkupTemplate("[b]---[/b]", state);
+
+		state.data.insertLast(dat);
+		tag.value = state.data.length-1;
+		tag.type = TT_Data;
+		state.wasPrintable = true;
+	}
+#section all
+	else if(tag.name == "template") {
+		int found = tag.argument.findFirst(strSemicolon);
+		string type, arg;
+
+		if(found == -1) {
+			type = tag.argument;
+		}
+		else {
+			type = tag.argument.substr(0, found);
+			arg = tag.argument.substr(found+1, tag.argument.length - found - 1);
+		}
+
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.wasPrintable = true;
+
+#section game
+		if(type == "resource") {
+			const ResourceType@ r = getResource(arg);
+			if(r !is null) {
+				string code = format("[nl/][img=$1][font=Subtitle][b][color=$2]$3 [img=$5;20/][/color][/b][/font][br/]$4[/img]",
+					getSpriteDesc(r.icon),
+					toString(getResourceRarityColor(r.rarity)), r.name,
+					getResourceTooltip(r, null, null, false).replaced("\n", "[br/]"),
+					getSpriteDesc(r.smallIcon));
+
+				state.data.insertLast(MarkupTemplate(code, state));
+				tag.value = state.data.length-1; //Because MarkupTemplate can add to state.data list
+			}
+			else
+				state.data.insertLast(MarkupData());
+		}
+		else if(type == "resource_ref") {
+			const ResourceType@ r = getResource(arg);
+			if(r !is null)
+				state.data.insertLast(MarkupSmallResource(r));
+			else
+				state.data.insertLast(MarkupData());
+		}
+		else if(type == "orbital_ref") {
+			auto@ d = getOrbitalModule(arg);
+			if(d !is null)
+				state.data.insertLast(MarkupReference(d.icon, d.getTooltip(), d.name, Color(0xffffff10), 22));
+			else
+				state.data.insertLast(MarkupData());
+		}
+		else if(type == "orbital") {
+			auto@ d = getOrbitalModule(arg);
+			if(d !is null) {
+				string code = format("[nl/][img=$2;38]$1",
+					d.getTooltip().replaced("\n", "[br/]"),
+					getSpriteDesc(d.icon));
+				state.data.insertLast(MarkupTemplate(code, state));
+				tag.value = state.data.length-1;
+			}
+			else
+				state.data.insertLast(MarkupData());
+		}
+		else if(type == "building_ref") {
+			const BuildingType@ d = getBuildingType(arg);
+			if(d !is null)
+				state.data.insertLast(MarkupReference(d.sprite, d.getTooltip(), d.name, Color(0xffffff10), 22));
+			else
+				state.data.insertLast(MarkupData());
+		}
+		else if(type == "subsys_ref") {
+			auto@ s = getSubsystemDef(arg);
+			if(s !is null)
+				state.data.insertLast(MarkupReference(s.picture, format("[b]$1[/b]\n\n$2", s.name, s.description), s.name, Color(0xffffff10), 22));
+			else
+				state.data.insertLast(MarkupData());
+		}
+		else if(type == "building") {
+			const BuildingType@ d = getBuildingType(arg);
+			if(d !is null) {
+				string code = format("[nl/][img=$1][font=Subtitle][b]$2[/b][/font][br/]$3[/img]",
+					getSpriteDesc(d.sprite),
+					d.name,
+					d.getTooltip(false).replaced("\n", "[br/]"));
+				state.data.insertLast(MarkupTemplate(code, state));
+				tag.value = state.data.length-1;
+			}
+			else
+				state.data.insertLast(MarkupData());
+		}
+		else
+#section all
+		{
+			state.data.insertLast(MarkupData());
+		}
+	}
+	else if(tag.name == "url") {
+		tag.type = TT_Data;
+
+		MarkupLink link;
+		link.link = tag.argument;
+		bbToPlainText(tag, link.text);
+
+		tag.value = state.data.length;
+		state.data.insertLast(link);
+		state.wasPrintable = true;
+	}
+	else if(tag.name.length > 1 && tag.name[0] == '[') {
+		int found = tag.name.findFirst("|");
+		MarkupLink link;
+
+		if(found == -1) {
+			link.link = tag.name.substr(1, tag.name.length - 1);
+			link.text = link.link;
+		}
+		else {
+			link.link = tag.name.substr(1, found-1);
+			link.text = tag.name.substr(found+1, tag.argument.length - found - 1);
+		}
+
+		tag.type = TT_Data;
+		tag.value = state.data.length;
+		state.data.insertLast(link);
+		state.wasPrintable = true;
+	}
+
+	for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+		markupParse(tag.children[i], state);
+
+	if(setUnprintable)
+		state.wasPrintable = false;
+}
+
+//The draw step draws anything that doesn't need its own element to do
+void markupComp(const Skin@ skin, MarkupState@ state, BBTag@ tag, MarkupMode mode) {
+	switch(tag.type) {
+		case TT_Text: {
+			vec2i prev = state.pos;
+			state.lineHeight = max(state.lineHeight, state.font.getLineHeight());
+			if(state.expandWidth) {
+				vec2i dim = state.font.getDimension(tag.argument);
+				if(mode == MM_Draw)
+					state.font.draw(state.pos, tag.argument, state.color);
+				state.pos.x += dim.x;
+			}
+			else {
+				if(mode == MM_Draw) {
+					state.pos = state.font.draw(
+							state.area, state.pos - state.area.topLeft,
+							state.lineHeight, tag.argument, state.color,
+							stroke=state.stroke);
+				}
+				else {
+					state.pos = state.font.getEndPosition(
+							state.area, state.pos - state.area.topLeft,
+							state.lineHeight, tag.argument);
+				}
+			}
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			if(prev.y != state.pos.y) {
+				if(state.pos.x == state.area.topLeft.x)
+					state.lineHeight = -1;
+				else
+					state.lineHeight = state.font.getLineHeight();
+			}
+		} break;
+		case TT_BR:
+			state.linebreak();
+		break;
+		case TT_NL:
+			if(state.pos.x != state.area.topLeft.x)
+				state.linebreak();
+		break;
+		case TT_Font: {
+			const Font@ prev = state.font;
+			@state.font = skin.getFont(FontType(tag.value));
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			@state.font = prev;
+		} break;
+		case TT_Bold: {
+			const Font@ prev = state.font;
+			if(prev.bold !is null)
+				@state.font = prev.bold;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			@state.font = prev;
+		} break;
+		case TT_Italic: {
+			const Font@ prev = state.font;
+			if(prev.italic !is null)
+				@state.font = prev.italic;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			@state.font = prev;
+		} break;
+		case TT_Color: {
+			Color prev = state.color;
+			state.color.color = tag.value;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.color = prev;
+		} break;
+		case TT_Stroke: {
+			Color prev = state.stroke;
+			state.stroke.color = tag.value;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.stroke = prev;
+		} break;
+		case TT_SkinColor: {
+			Color prev = state.color;
+			state.color = skin.getColor(SkinColor(tag.value));
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.color = prev;
+		} break;
+		case TT_HSpace: {
+			state.pos.x += tag.value;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			if(tag.childCount > 0)
+				state.pos.x -= tag.value;
+		} break;
+		case TT_VSpace: {
+			state.pos.y += tag.value;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			if(tag.childCount > 0)
+				state.pos.y -= tag.value;
+		} break;
+		case TT_VBlock: {
+			int prevY = state.pos.y;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.pos.y += max(tag.value - (state.pos.y - prevY), 0);
+		} break;
+		case TT_Offset: {
+			int prevStart = state.area.topLeft.x;
+			if(state.pos.x - state.area.topLeft.x < tag.value)
+				state.pos.x = tag.value + state.area.topLeft.x;
+			state.area.topLeft.x = state.pos.x;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.area.topLeft.x = prevStart;
+		} break;
+		case TT_Padding: {
+			if(state.pos.x - state.area.topLeft.x < tag.value)
+				state.pos.x = tag.value + state.area.topLeft.x;
+			state.area.topLeft.x += tag.value;
+			state.area.botRight.x -= tag.value;
+			for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+				markupComp(skin, state, tag.children[i], mode);
+			state.area.topLeft.x -= tag.value;
+			state.area.botRight.x += tag.value;
+		} break;
+		case TT_Data: {
+			state.data[tag.value].comp(skin, state, tag, mode);
+		} break;
+		case TT_DLC: {
+			if(hasDLC(tag.argument)) {
+				for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+					markupComp(skin, state, tag.children[i], mode);
+			}
+		} break;
+	}
+}
+
+void bbToPlainText(BBTag@ tag, string& text) {
+	switch(tag.type) {
+		case -1:
+		case TT_Text:
+			text += tag.argument;
+		break;
+	}
+
+	for(uint i = 0, cnt = tag.childCount; i < cnt; ++i)
+		bbToPlainText(tag.children[i], text);
+}
+
+class MarkupRenderer {
+	BBCode tree;
+	MarkupState state;
+	int prevWidth = -1;
+	int height = 100;
+	int width = 100;
+	bool prepared = false;
+	FontType defaultFont = FT_Normal;
+	Color defaultColor;
+	Color defaultStroke = colors::Invisible;
+
+	void clear() {
+		tree.clear();
+	}
+
+	void set_expandWidth(bool v) {
+		state.expandWidth = v;
+	}
+
+	void set_paragraphize(bool v) {
+		state.paragraphize = v;
+	}
+
+	void parse(const Skin@ skin, const string& str, const recti& pos) {
+		parseTree(str);
+		parseElements(skin, pos);
+	}
+
+	int getAnchor(const string& name) {
+		return getAnchor(name, tree.root);
+	}
+
+	int getAnchor(const string& name, BBTag@ tag) {
+		if(tag.type == TT_Data) {
+			MarkupData@ dat = state.data[tag.value];
+			if(dat.anchor == name)
+				return dat.anchorPosition;
+		}
+
+		for(uint i = 0, cnt = tag.childCount; i < cnt; ++i) {
+			int pos = getAnchor(name, tag.children[i]);
+			if(pos != -1)
+				return pos;
+		}
+
+		return -1;
+	}
+
+	void parseTree(const string& str) {
+		tree.parse(str);
+		prevWidth = -1;
+		prepared = false;
+	}
+
+	string getPlainText(const Skin@ skin, const recti& pos) {
+		if(!prepared)
+			parseElements(skin, pos);
+		string text;
+		bbToPlainText(tree.root, text);
+		return text;
+	}
+
+	void parseElements(const Skin@ skin, const recti& pos) {
+		BBTag@ root = tree.root;
+		state.reset(skin, pos, defaultFont, defaultColor, defaultStroke);
+		state.data.length = 0;
+		for(uint i = 0, cnt = root.childCount; i < cnt; ++i)
+			markupParse(root.children[i], state);
+		prevWidth = -1;
+		prepared = true;
+	}
+
+	void update(const Skin@ skin, const recti& pos) {
+		if(!prepared)
+			parseElements(skin, pos);
+		if(pos.size.width != prevWidth) {
+			state.reset(skin, pos, defaultFont, defaultColor, defaultStroke);
+			BBTag@ root = tree.root;
+			for(uint i = 0, cnt = root.childCount; i < cnt; ++i)
+				markupComp(skin, state, root.children[i], MM_Layout);
+			prevWidth = pos.size.width;
+			height = (state.pos.y - state.area.topLeft.y)+3;
+			if(state.pos.x > state.area.topLeft.x)
+				height += state.getLineHeight();
+			width = max(state.maxWidth, state.pos.x - state.area.topLeft.x);
+		}
+	}
+
+	void draw(const Skin@ skin, const recti& pos) {
+		if(pos.size.width != prevWidth)
+			update(skin, pos);
+		state.reset(skin, pos, defaultFont, defaultColor, defaultStroke);
+		BBTag@ root = tree.root;
+		for(uint i = 0, cnt = root.childCount; i < cnt; ++i)
+			markupComp(skin, state, root.children[i], MM_Draw);
+	}
+};
+
+class GuiMarkupText : BaseGuiElement {
+	MarkupRenderer renderer;
+	bool flexHeight = true;
+	bool fitWidth = false;
+	int Padding = 2;
+	int hovered = -1;
+	string text;
+	bool memo = false;
+
+	GuiMarkupText(IGuiElement@ ParentElement, Alignment@ Align) {
+		super(ParentElement, Align);
+		updateAbsolutePosition();
+		renderer.defaultColor = skin.getColor(SC_Text);
+	}
+
+	GuiMarkupText(IGuiElement@ ParentElement, const recti& pos) {
+		super(ParentElement, pos);
+		updateAbsolutePosition();
+		renderer.defaultColor = skin.getColor(SC_Text);
+	}
+
+	GuiMarkupText(IGuiElement@ ParentElement, Alignment@ Align, const string& txt) {
+		super(ParentElement, Align);
+		text = txt;
+		updateAbsolutePosition();
+		renderer.defaultColor = skin.getColor(SC_Text);
+	}
+
+	GuiMarkupText(IGuiElement@ ParentElement, const recti& pos, const string& txt) {
+		super(ParentElement, pos);
+		text = txt;
+		updateAbsolutePosition();
+		renderer.defaultColor = skin.getColor(SC_Text);
+	}
+
+	int getAnchor(const string& name) {
+		return renderer.getAnchor(name);
+	}
+
+	string get_plainText() {
+		return renderer.getPlainText(skin, AbsolutePosition.padded(Padding));
+	}
+
+	void clear() {
+		renderer.clear();
+	}
+
+	void set_defaultColor(Color col) {
+		renderer.defaultColor = col;
+	}
+
+	void set_defaultStroke(Color col) {
+		renderer.defaultStroke = col;
+	}
+
+	void set_defaultFont(FontType type) {
+		renderer.defaultFont = type;
+	}
+
+	void set_expandWidth(bool value) {
+		renderer.expandWidth = value;
+	}
+
+	void set_paragraphize(bool value) {
+		renderer.paragraphize = value;
+	}
+
+	int get_textWidth() {
+		return renderer.width;
+	}
+
+	void set_padding(int padd) {
+		Padding = padd;
+		updateAbsolutePosition();
+	}
+
+	void set_text(const string& str) {
+		if(memo) {
+			if(text == str)
+				return;
+		}
+		renderer.parseTree(str);
+		if(memo)
+			text = str;
+	}
+
+#section game
+	void set_targets(const Targets@ targs) {
+		if(targs is null) {
+			@renderer.state.targets = null;
+		}
+		else {
+			@renderer.state.targets = Targets();
+			renderer.state.targets = targs;
+		}
+	}
+#section all
+
+	string get_tooltip() override {
+		if(hovered != -1 && hovered < int(renderer.state.data.length))
+			return renderer.state.data[hovered].tooltip;
+		return "";
+	}
+
+	bool onGuiEvent(const GuiEvent& event) override {
+		if(event.caller is this) {
+			switch(event.type) {
+				case GUI_Mouse_Left:
+					hovered = -1;
+				break;
+			}
+		}
+		return BaseGuiElement::onGuiEvent(event);
+	}
+
+	int getOffsetItem(vec2i absPos) {
+		for(int i = renderer.state.data.length - 1; i >= 0; --i) {
+			MarkupData@ dat = renderer.state.data[i];
+			if(dat.contains(skin, renderer.state, absPos))
+				return i;
+		}
+		return -1;
+	}
+
+	bool onMouseEvent(const MouseEvent& event, IGuiElement@ source) override {
+		if(source is this) {
+			switch(event.type) {
+				case MET_Moved: {
+					int prevHovered = hovered;
+					hovered = getOffsetItem(mousePos);
+					if(prevHovered != hovered) {
+						if(prevHovered != -1 && prevHovered < int(renderer.state.data.length))
+							renderer.state.data[prevHovered].hovered = false;
+						if(hovered != -1 && hovered < int(renderer.state.data.length))
+							renderer.state.data[hovered].hovered = true;
+						if(tooltipObject !is null)
+							tooltipObject.update(skin, this);
+					}
+				} break;
+				case MET_Button_Down:
+					if(hovered != -1 && hovered < int(renderer.state.data.length))
+						if(renderer.state.data[hovered].onClick(this, event.button, true))
+							return true;
+				break;
+				case MET_Button_Up:
+					if(hovered != -1 && hovered < int(renderer.state.data.length)) {
+						if(renderer.state.data[hovered].onClick(this, event.button, false))
+							return true;
+					}
+				break;
+			}
+		}
+		return BaseGuiElement::onMouseEvent(event, source);
+	}
+
+	void onLinkClicked(const string& link, int button) {
+	}
+
+	void updateAbsolutePosition() {
+		BaseGuiElement::updateAbsolutePosition();
+		renderer.update(skin, AbsolutePosition.padded(Padding));
+		if(Alignment is null) {
+			vec2i sz = size;
+			if(flexHeight)
+				sz = vec2i(renderer.state.expandWidth ? textWidth+6 : Position.size.width, renderer.height + Padding * 2);
+			if(fitWidth) {
+				sz.x = parent.size.width - (position.x*2);
+				GuiPanel@ pan = cast<GuiPanel>(parent);
+				if(pan !is null && pan.vert.visible)
+					sz.x -= pan.vert.size.width;
+			}
+			size = sz;
+		}
+	}
+
+	void draw() {
+		renderer.draw(skin, AbsolutePosition.padded(Padding));
+		if(hovered < 0 || hovered > int(renderer.state.data.length))
+			hovered = -1;
+		BaseGuiElement::draw();
+	}
+};

--- a/SR2 Community Patch/scripts/toolkit/elements/GuiMarkupText.as
+++ b/SR2 Community Patch/scripts/toolkit/elements/GuiMarkupText.as
@@ -747,7 +747,10 @@ void markupParse(BBTag@ tag, MarkupState@ state){
 	else if(tag.name == "hr") {
 		tag.type = TT_Data;
 		tag.value = state.data.length;
-		state.data.insertLast(MarkupLine());
+		MarkupLine ml = MarkupLine();
+		if(tag.argument.length > 0 && tag.argument[0] == '#')
+			ml.color = toColor(tag.argument);
+		state.data.insertLast(ml);
 		state.wasPrintable = false;
 	}
 	else if(tag.name == "levels") {


### PR DESCRIPTION
Well, I was bothered by that vertical offset in the Budget overview, that escalated a bit, as always...

This de-bloats the global popups a bit, removes the offset and adds some contrast and lines, so it's not that hard on the eyes... It really helps on large resolutions, check the highres pic.

One locale is actually modified to be a bit shorter... (Galactic Stake Percentage)
The BBCode [hr] tag had a hardcoded gray color value, this change makes it possible to pass a color in markup text, like for other tags.

# before
![screenshot88_](https://user-images.githubusercontent.com/681397/91622739-de2ccc00-e998-11ea-9148-4abe145e96fb.png)

# after
![screenshot77_](https://user-images.githubusercontent.com/681397/91622733-d66d2780-e998-11ea-9e48-06702068a611.png)

# highres
![screenshot89_](https://user-images.githubusercontent.com/681397/91622848-5bf0d780-e999-11ea-84f8-22c2b11a739c.png)
